### PR TITLE
catch potential silero errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -154,7 +154,12 @@ export class SpeechRecorder {
     let probability = speaking ? 1 : 0;
 
     // double-check the WebRTC VAD with the Silero VAD
-    if (!this.disableSecondPass && speaking && this.vadBuffer.length == this.vadBufferSize) {
+    if (
+      !this.disableSecondPass &&
+      speaking &&
+      this.vadBuffer.length == this.vadBufferSize &&
+      this.vad.ready
+    ) {
       probability = await this.vad.process([].concat(...this.vadBuffer));
       speaking = probability > this.vadThreshold;
 
@@ -228,7 +233,11 @@ export class SpeechRecorder {
     }
   }
 
-  start(startOptions: any = {}) {
+  async start(startOptions: any = {}) {
+    if (!this.disableSecondPass) {
+      await this.vad.load();
+    }
+
     this.leadingBuffer = [];
     this.audioStream = new AudioStream({
       channelCount: 1,

--- a/vad.ts
+++ b/vad.ts
@@ -1,22 +1,50 @@
-const ort = require("onnxruntime");
-
 export default class SileroVad {
   private loaded = false;
+  private ort: any;
   private session: any;
 
-  private async load() {
+  public ready = false;
+
+  async load() {
     if (this.loaded) {
       return;
     }
 
-    this.session = await ort.InferenceSession.create(`${__dirname}/../model/silero.onnx`);
     this.loaded = true;
+    try {
+      this.ort = require("onnxruntime");
+    } catch (e) {
+      return;
+    }
+
+    if (!this.ort) {
+      return;
+    }
+
+    try {
+      this.session = await this.ort.InferenceSession.create(`${__dirname}/../model/silero.onnx`);
+    } catch (e) {
+      return;
+    }
+
+    if (!this.session) {
+      return;
+    }
+
+    this.ready = true;
   }
 
   async process(audio: number[], batchSize = 1): Promise<number> {
-    await this.load();
+    if (!this.loaded) {
+      await this.load();
+    }
+
+    if (!this.ready) {
+      return 0;
+    }
+
     const result = await this.session.run({
-      input: new ort.Tensor(Float32Array.from(audio), [batchSize, audio.length / batchSize]),
+      input: new this.ort.Tensor(Float32Array.from(audio), [batchSize, audio.length / batchSize]),
     });
 
     return result.output.data[1];


### PR DESCRIPTION
onnx isn't compatible with some versions of windows, so catch errors in
the loading process and disable it. also make the disableSecondPass
option not load the module at all, rather than loading it but then not
using it.