### PR TITLE
add public load method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -130,6 +130,12 @@ export class SpeechRecorder {
     this.webrtcVad = new WebrtcVad(this.sampleRate, options.firstPassLevel || 3);
   }
 
+  async load() {
+    if (!this.disableSecondPass) {
+      await this.vad.load();
+    }
+  }
+
   async onData(startOptions: any, audio: any) {
     let sum = 0;
     let normalized: number[] = [];
@@ -234,10 +240,7 @@ export class SpeechRecorder {
   }
 
   async start(startOptions: any = {}) {
-    if (!this.disableSecondPass) {
-      await this.vad.load();
-    }
-
+    await this.load();
     this.leadingBuffer = [];
     this.audioStream = new AudioStream({
       channelCount: 1,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speech-recorder",
   "author": "Serenade Labs, Inc. <contact@serenade.ai>",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Record speech via PortAudio and WebRTC VAD bindings.",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
rather than implicitly loading the VAD model when the mic starts,
provide a public method that allows the caller to load the model
whenever it wants.