### PR TITLE
fix linking for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ dist
 node_modules
 lib/3rd_party/portaudio
 lib/3rd_party/onnxruntime
+lib/install
 prebuilds

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,9 +39,9 @@
                             {
                                 "destination": "<(module_root_dir)/build/Release",
                                 "files": [
-                                    "<(module_root_dir)/lib/build/libspeechrecorder.dylib",
-                                    "<(module_root_dir)/lib/3rd_party/portaudio/lib/libportaudio.dylib",
-                                    "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/libonnxruntime.1.10.0.dylib",
+                                    "<(module_root_dir)/lib/install/lib/libspeechrecorder.dylib",
+                                    "<(module_root_dir)/lib/install/lib/libportaudio.dylib",
+                                    "<(module_root_dir)/lib/install/lib/libonnxruntime.1.10.0.dylib",
                                 ],
                             }
                         ],
@@ -64,16 +64,16 @@
                             {
                                 "destination": "<(module_root_dir)/build/Release",
                                 "files": [
-                                    "<(module_root_dir)/lib/build/Release/speechrecorder.dll",
-                                    "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/onnxruntime.dll",
-                                    "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/onnxruntime_providers_shared.dll",
+                                    "<(module_root_dir)/lib/install/lib/speechrecorder.dll",
+                                    "<(module_root_dir)/lib/install/lib/onnxruntime.dll",
+                                    "<(module_root_dir)/lib/install/lib/onnxruntime_providers_shared.dll",
                                 ],
                             }
                         ],
                         "libraries": [
-                            "<(module_root_dir)/lib/build/Release/speechrecorder.lib",
-                            "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/onnxruntime.lib",
-                            "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/onnxruntime_providers_shared.lib",
+                            "<(module_root_dir)/lib/install/lib/speechrecorder.lib",
+                            "<(module_root_dir)/lib/install/lib/onnxruntime.lib",
+                            "<(module_root_dir)/lib/install/lib/onnxruntime_providers_shared.lib",
                         ],
                     },
                 ],
@@ -84,13 +84,13 @@
                             {
                                 "destination": "<(module_root_dir)/build/Release",
                                 "files": [
-                                    "<(module_root_dir)/lib/3rd_party/portaudio/bin/portaudio_x86.dll",
+                                    "<(module_root_dir)/lib/install/lib/portaudio_x86.dll",
                                     "<(module_root_dir)/lib/3rd_party/vcruntime/x86/vcruntime140.dll",
                                 ],
                             }
                         ],
                         "libraries": [
-                            "<(module_root_dir)/lib/3rd_party/portaudio/lib/portaudio_x86.lib",
+                            "<(module_root_dir)/lib/install/lib/portaudio_x86.lib",
                         ],
                     },
                 ],
@@ -101,27 +101,31 @@
                             {
                                 "destination": "<(module_root_dir)/build/Release",
                                 "files": [
-                                    "<(module_root_dir)/lib/3rd_party/portaudio/bin/portaudio_x64.dll",
+                                    "<(module_root_dir)/lib/install/lib/portaudio_x64.dll",
                                     "<(module_root_dir)/lib/3rd_party/vcruntime/x64/vcruntime140.dll",
                                 ],
                             }
                         ],
                         "libraries": [
-                            "<(module_root_dir)/lib/3rd_party/portaudio/lib/portaudio_x64.lib",
+                            "<(module_root_dir)/lib/install/lib/portaudio_x64.lib",
                         ],
                     },
                 ],
                 [
                     'OS=="linux"',
                     {
-                        "link_settings": {"ldflags": ["-Wl,-rpath,'$$ORIGIN/'"]},
+                        "link_settings": {
+                            "libraries": [
+                                "-Wl,-rpath,'$$ORIGIN'",
+                            ]
+                        },
                         "copies": [
                             {
                                 "destination": "<(module_root_dir)/build/Release",
                                 "files": [
-                                    "<(module_root_dir)/lib/build/libspeechrecorder.so",
-                                    "<(module_root_dir)/lib/3rd_party/portaudio/lib/libportaudio.so",
-                                    "<(module_root_dir)/lib/3rd_party/onnxruntime/lib/libonnxruntime.so.1.10.0",
+                                    "<(module_root_dir)/lib/install/lib/libspeechrecorder.so",
+                                    "<(module_root_dir)/lib/install/lib/libportaudio.so",
+                                    "<(module_root_dir)/lib/install/lib/libonnxruntime.so.1.10.0",
                                 ],
                             }
                         ],

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ if [[ -z "$1" ]] ; then
   exit 1
 fi
 
-rm -rf lib/build
+rm -rf lib/build lib/install
 mkdir -p lib/build
 cd lib/build
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,6 @@ if [[ -z "$1" ]] ; then
   exit 1
 fi
 
-yarn
 rm -rf lib/build
 mkdir -p lib/build
 cd lib/build

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ if [[ -z "$1" ]] ; then
   exit 1
 fi
 
+yarn
 rm -rf lib/build
 mkdir -p lib/build
 cd lib/build
@@ -30,6 +31,7 @@ else
 fi
 
 cmake --build . --config Release
+cmake --install . --prefix ../install
 
 cd ../..
 rm -rf prebuilds
@@ -41,7 +43,7 @@ fi
 
 eval "npm_config_arch=$node_arch ./node_modules/.bin/node-gyp rebuild"
 
-prebuild_command="./node_modules/.bin/prebuild -r napi --include-regex '.(node|a|dylib|dll|so)$' --arch=$node_arch"
+prebuild_command="./node_modules/.bin/prebuild -r napi --include-regex '.(node|a|dylib|dll|so.*)$' --arch=$node_arch"
 if [[ -n "$2" ]] ; then
   prebuild_command+=" --upload $2"
 fi

--- a/examples/devices.js
+++ b/examples/devices.js
@@ -1,3 +1,3 @@
-const { devices } = require("../src/index.js");
+const { devices } = require("../src/index");
 
 console.log(devices());

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,13 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-if(APPLE OR NOT WIN32)
+if(NOT APPLE AND NOT WIN32)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif()
-
-if(APPLE)
-    set(MACOSX_RPATH TRUE)
-elseif(NOT WIN32)
     set(CMAKE_INSTALL_RPATH "$ORIGIN/")
 endif()
 
@@ -72,7 +67,7 @@ if(APPLE)
         "-framework CoreFoundation"
         "-framework CoreServices"
         portaudio
-        onnxruntime
+        onnxruntime.1.10.0
     )
 elseif(WIN32)
     list(APPEND LIBRARIES
@@ -130,9 +125,12 @@ if (WIN32)
 elseif(APPLE)
     install(
         FILES
-            3rd_party/onnxruntime/lib/libonnxruntime.dylib
             3rd_party/onnxruntime/lib/libonnxruntime.1.10.0.dylib
             3rd_party/portaudio/lib/libportaudio.dylib
+        PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
         DESTINATION lib
     )
 else()
@@ -141,6 +139,10 @@ else()
             3rd_party/onnxruntime/lib/libonnxruntime.so
             3rd_party/onnxruntime/lib/libonnxruntime.so.1.10.0
             3rd_party/portaudio/lib/libportaudio.so
+        PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
         DESTINATION lib
     )
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,16 @@ project(speechrecorder)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-include(FetchContent)
+
+if(APPLE OR NOT WIN32)
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
+
+if(APPLE)
+    set(MACOSX_RPATH TRUE)
+elseif(NOT WIN32)
+    set(CMAKE_INSTALL_RPATH "$ORIGIN/")
+endif()
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
@@ -18,6 +27,7 @@ else()
     )
 endif()
 
+include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 
 FetchContent_Declare(drwav
@@ -92,28 +102,32 @@ target_link_libraries(speechrecorder ${LIBRARIES})
 add_executable(main test/main.cpp)
 target_link_libraries(main speechrecorder)
 
-if(WIN32)
-    add_custom_command(TARGET main POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${PROJECT_SOURCE_DIR}/3rd_party/onnxruntime/lib/onnxruntime.dll"
-            $<TARGET_FILE_DIR:main>
-
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${PROJECT_SOURCE_DIR}/3rd_party/onnxruntime/lib/onnxruntime_providers_shared.dll"
-            $<TARGET_FILE_DIR:main>
+install(TARGETS speechrecorder DESTINATION lib)
+if (WIN32)
+    install(
+        FILES
+            3rd_party/onnxruntime/lib/onnxruntime.dll
+            3rd_party/onnxruntime/lib/onnxruntime_providers_shared.dll
+        DESTINATION lib
     )
-
     if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
-        add_custom_command(TARGET main POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${PROJECT_SOURCE_DIR}/3rd_party/portaudio/bin/portaudio_x86.dll"
-                $<TARGET_FILE_DIR:main>
-        )
+        install(FILES 3rd_party/portaudio/bin/portaudio_x86.dll DESTINATION lib)
     else()
-        add_custom_command(TARGET main POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${PROJECT_SOURCE_DIR}/3rd_party/portaudio/bin/portaudio_x64.dll"
-                $<TARGET_FILE_DIR:main>
-        )
+        install(FILES 3rd_party/portaudio/bin/portaudio_x64.dll DESTINATION lib)
     endif()
+elseif(APPLE)
+    install(
+        FILES
+            3rd_party/onnxruntime/lib/libonnxruntime.1.10.0.dylib
+            3rd_party/portaudio/lib/libportaudio.dylib
+        DESTINATION lib
+    )
+else()
+    install(
+        FILES
+            3rd_party/onnxruntime/lib/libonnxruntime.so
+            3rd_party/onnxruntime/lib/libonnxruntime.so.1.10.0
+            3rd_party/portaudio/lib/libportaudio.so
+        DESTINATION lib
+    )
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -72,7 +72,7 @@ if(APPLE)
         "-framework CoreFoundation"
         "-framework CoreServices"
         portaudio
-        onnxruntime.1.10.0
+        onnxruntime
     )
 elseif(WIN32)
     list(APPEND LIBRARIES
@@ -118,6 +118,7 @@ if (WIN32)
 elseif(APPLE)
     install(
         FILES
+            3rd_party/onnxruntime/lib/libonnxruntime.dylib
             3rd_party/onnxruntime/lib/libonnxruntime.1.10.0.dylib
             3rd_party/portaudio/lib/libportaudio.dylib
         DESTINATION lib

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -107,13 +107,25 @@ if (WIN32)
     install(
         FILES
             3rd_party/onnxruntime/lib/onnxruntime.dll
+            3rd_party/onnxruntime/lib/onnxruntime.lib
             3rd_party/onnxruntime/lib/onnxruntime_providers_shared.dll
+            3rd_party/onnxruntime/lib/onnxruntime_providers_shared.lib
         DESTINATION lib
     )
     if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
-        install(FILES 3rd_party/portaudio/bin/portaudio_x86.dll DESTINATION lib)
+        install(
+            FILES
+                3rd_party/portaudio/bin/portaudio_x86.dll
+                3rd_party/portaudio/lib/portaudio_x86.lib
+            DESTINATION lib
+        )
     else()
-        install(FILES 3rd_party/portaudio/bin/portaudio_x64.dll DESTINATION lib)
+        install(
+            FILES
+                3rd_party/portaudio/bin/portaudio_x64.dll
+                3rd_party/portaudio/lib/portaudio_x64.lib
+            DESTINATION lib
+        )
     endif()
 elseif(APPLE)
     install(

--- a/lib/include/devices.h
+++ b/lib/include/devices.h
@@ -13,6 +13,18 @@ struct Device {
   double defaultSampleRate;
   bool isDefaultInput;
   bool isDefaultOutput;
+
+  Device(int id, std::string name, std::string apiName, int maxInputChannels,
+         int maxOutputChannels, double defaultSampleRate, bool isDefaultInput,
+         bool isDefaultOutput)
+      : id(id),
+        name(name),
+        apiName(apiName),
+        maxInputChannels(maxInputChannels),
+        maxOutputChannels(maxOutputChannels),
+        defaultSampleRate(defaultSampleRate),
+        isDefaultInput(isDefaultInput),
+        isDefaultOutput(isDefaultOutput) {}
 };
 
 std::vector<Device> GetDevices();

--- a/lib/src/devices.cpp
+++ b/lib/src/devices.cpp
@@ -23,15 +23,11 @@ std::vector<Device> GetDevices() {
 #endif
 
     if (include) {
-      Device device = {i,
-                       info->name,
-                       Pa_GetHostApiInfo(info->hostApi)->name,
-                       info->maxInputChannels,
-                       info->maxOutputChannels,
-                       info->defaultSampleRate,
-                       i == Pa_GetDefaultInputDevice(),
-                       i == Pa_GetDefaultOutputDevice()};
-      result.push_back(device);
+      result.emplace_back(i, info->name, Pa_GetHostApiInfo(info->hostApi)->name,
+                          info->maxInputChannels, info->maxOutputChannels,
+                          info->defaultSampleRate,
+                          i == Pa_GetDefaultInputDevice(),
+                          i == Pa_GetDefaultOutputDevice());
     }
   }
 

--- a/lib/src/devices.cpp
+++ b/lib/src/devices.cpp
@@ -24,13 +24,13 @@ std::vector<Device> GetDevices() {
 
     if (include) {
       Device device = {i,
-                      info->name,
-                      Pa_GetHostApiInfo(info->hostApi)->name,
-                      info->maxInputChannels,
-                      info->maxOutputChannels,
-                      info->defaultSampleRate,
-                      i == Pa_GetDefaultInputDevice(),
-                      i == Pa_GetDefaultOutputDevice()};
+                       info->name,
+                       Pa_GetHostApiInfo(info->hostApi)->name,
+                       info->maxInputChannels,
+                       info->maxOutputChannels,
+                       info->defaultSampleRate,
+                       i == Pa_GetDefaultInputDevice(),
+                       i == Pa_GetDefaultOutputDevice()};
       result.push_back(device);
     }
   }

--- a/lib/src/devices.cpp
+++ b/lib/src/devices.cpp
@@ -14,15 +14,25 @@ std::vector<Device> GetDevices() {
   int count = Pa_GetDeviceCount();
   for (int i = 0; i < count; i++) {
     const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
-    Device device = {i,
-                     info->name,
-                     Pa_GetHostApiInfo(info->hostApi)->name,
-                     info->maxInputChannels,
-                     info->maxOutputChannels,
-                     info->defaultSampleRate,
-                     i == Pa_GetDefaultInputDevice(),
-                     i == Pa_GetDefaultOutputDevice()};
-    result.push_back(device);
+    bool include = info->maxInputChannels > 0;
+
+#ifdef WIN32
+    if (strcmp(Pa_GetHostApiInfo(info->hostApi)->name, "MME") != 0) {
+      include = false;
+    }
+#endif
+
+    if (include) {
+      Device device = {i,
+                      info->name,
+                      Pa_GetHostApiInfo(info->hostApi)->name,
+                      info->maxInputChannels,
+                      info->maxOutputChannels,
+                      info->defaultSampleRate,
+                      i == Pa_GetDefaultInputDevice(),
+                      i == Pa_GetDefaultOutputDevice()};
+      result.push_back(device);
+    }
   }
 
   return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speech-recorder",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A node.js library for streaming audio and speech from the microphone.",
   "main": "src/index.js",
   "repository": "https://github.com/serenadeai/speech-recorder",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "bash build.sh",
-    "clean": "rm -rf build prebuilds lib/build",
+    "clean": "rm -rf build prebuilds lib/build lib/install",
     "install": "prebuild-install -r napi || node-gyp rebuild"
   },
   "dependencies": {

--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ cd portaudio
 mkdir dist install
 cd dist
 
-portaudio_cmake="cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
+portaudio_cmake="cmake"
 if [[ `uname -s` == "MINGW"* ]] ; then
   if [[ "$1" == "x86" ]] ; then
     portaudio_cmake+=" -A Win32"
@@ -28,6 +28,7 @@ if [[ `uname -s` == "MINGW"* ]] ; then
     portaudio_cmake+=" -A x64"
   fi
 elif [[ `uname -s` == "Darwin" ]] ; then
+  portaudio_cmake+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
   if [[ "$1" == "x64" ]] ; then
     portaudio_cmake+=" -DCMAKE_OSX_ARCHITECTURES=x86_64"
   elif [[ "$1" == "arm64" ]] ; then

--- a/setup.sh
+++ b/setup.sh
@@ -41,9 +41,6 @@ eval $portaudio_cmake
 cmake --build . --config Release
 cmake --install . --prefix ../install
 cp -r ../install ../../../../lib/3rd_party/portaudio
-if [[ `uname -s` == "Linux" ]] ; then
-  chmod +x ../../../../lib/3rd_party/portaudio/lib/libportaudio.so
-fi
 
 cd ../../..
 mkdir onnxruntime

--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ cd portaudio
 mkdir dist install
 cd dist
 
-portaudio_cmake="cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
+portaudio_cmake="cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
 if [[ `uname -s` == "MINGW"* ]] ; then
   if [[ "$1" == "x86" ]] ; then
     portaudio_cmake+=" -A Win32"
@@ -38,8 +38,9 @@ fi
 portaudio_cmake+=" .."
 eval $portaudio_cmake
 cmake --build . --config Release
-cmake --install .
+cmake --install . --prefix ../install
 cp -r ../install ../../../../lib/3rd_party/portaudio
+chmod +x ../../../../lib/3rd_party/portaudio/lib/libportaudio.so
 
 cd ../../..
 mkdir onnxruntime

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,9 @@ eval $portaudio_cmake
 cmake --build . --config Release
 cmake --install . --prefix ../install
 cp -r ../install ../../../../lib/3rd_party/portaudio
-chmod +x ../../../../lib/3rd_party/portaudio/lib/libportaudio.so
+if [[ `uname -s` == "Linux" ]] ; then
+  chmod +x ../../../../lib/3rd_party/portaudio/lib/libportaudio.so
+fi
 
 cd ../../..
 mkdir onnxruntime


### PR DESCRIPTION
use RPATH for dependencies on macOS and linux to fix an issue where libportaudio couldn't be found on some platforms. also restrict devices list to only input devices with a compatible host API.