### PR TITLE
Fix device list not being updated

### DIFF
--- a/examples/devices.js
+++ b/examples/devices.js
@@ -1,3 +1,5 @@
 const { devices } = require("../src/index");
 
-console.log(devices());
+setInterval(() => {
+    console.log(devices());
+}, 5000);

--- a/lib/src/devices.cpp
+++ b/lib/src/devices.cpp
@@ -30,6 +30,7 @@ std::vector<Device> GetDevices() {
                           i == Pa_GetDefaultOutputDevice());
     }
   }
+  Pa_Terminate();
 
   return result;
 }


### PR DESCRIPTION
This draft PR fixes #36. By calling PA_terminate on every GetDevices call, we ensure the device list is properly updated. I modified the devices example to call GetDevices every 5 seconds, so it is easy to add/remove any device and verify this behavior (not sure if that should be another example, or if that is needed at all). 

I tested this fix on an Ubuntu 22.04, but didn´t manage to build on my Windows 10 (tried Msys2 MinGW64 and Cygwin). Is there a recommended setup for Windows builds? 